### PR TITLE
Add weighted team aggregation and mismatch scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,10 +184,10 @@ This will:
 - Generate team comparison reports in `data/out/`
 
 Output files include:
-- `team_defense_coverage.csv` – Team-level defensive coverage statistics
-- `team_receiving_concept.csv` – Team-level receiving concept metrics
-- `team_receiving_scheme.csv` – Team-level receiving scheme metrics
-- `team_summary.csv` – Combined summary with key metrics
+- `team_defense_coverage.csv` – Team-level defensive coverage statistics (player-game weighted)
+- `team_receiving_concept.csv` – Team-level receiving concept metrics (player-game weighted)
+- `team_receiving_scheme.csv` – Team-level receiving scheme metrics (player-game weighted)
+- `team_summary.csv` – Combined summary with key metrics plus an overall `mismatch_score` and tier
 
 #### Integrating with CFBD API Data
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -27,10 +27,10 @@ cfb-mismatch analyze
 ```
 
 This will generate team-level aggregations in `data/out/`:
-- `team_defense_coverage.csv` - Defensive coverage statistics by team
-- `team_receiving_concept.csv` - Receiving concept metrics by team
-- `team_receiving_scheme.csv` - Receiving scheme metrics by team
-- `team_summary.csv` - Combined summary with key metrics
+- `team_defense_coverage.csv` - Defensive coverage statistics by team (player-game weighted)
+- `team_receiving_concept.csv` - Receiving concept metrics by team (player-game weighted)
+- `team_receiving_scheme.csv` - Receiving scheme metrics by team (player-game weighted)
+- `team_summary.csv` - Combined summary with key metrics and an overall `mismatch_score`
 
 #### Integrate with CFBD API Data
 
@@ -61,9 +61,18 @@ The integrated summary includes additional columns:
 
 ### 3. View Results
 
-The summary report shows top-performing teams across different metrics:
+The summary report surfaces the overall mismatch leaderboard (based on the weights in
+`configs/weights.yaml`) alongside the supporting coverage/receiving metrics:
 
 ```
+--- Top 5 Teams by Overall Mismatch Score ---
+ team_name  mismatch_score mismatch_tier
+   INDIANA        0.705147         Elite
+   ARIZONA        0.645588         Elite
+  MO STATE        0.616176         Elite
+     TEXAS        0.608088         Elite
+NOTRE DAME        0.599265         Elite
+
 --- Top 5 Teams by Man Coverage Grade ---
  team_name  man_coverage_grade
   DOMINION           66.095238

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandas>=1.5.0
 pyyaml>=6.0
 requests>=2.28.0
+numpy>=1.24.0

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "pandas>=1.5.0",
         "pyyaml>=6.0",
         "requests>=2.28.0",
+        "numpy>=1.24.0",
     ],
     entry_points={
         "console_scripts": [

--- a/src/cfb_mismatch/adapters/receiving_concept.py
+++ b/src/cfb_mismatch/adapters/receiving_concept.py
@@ -2,8 +2,8 @@
 Adapter for loading receiving concept statistics.
 """
 
+import numpy as np
 import pandas as pd
-from typing import Optional
 
 
 def load_receiving_concept(file_path: str) -> pd.DataFrame:
@@ -34,25 +34,52 @@ def load_receiving_concept(file_path: str) -> pd.DataFrame:
 
 def aggregate_receiving_concept_by_team(df: pd.DataFrame) -> pd.DataFrame:
     """
-    Aggregate receiving concept stats by team.
-    
+    Aggregate receiving concept stats by team using player-game counts as weights.
+
     Args:
-        df: DataFrame from load_receiving_concept
-        
+        df: DataFrame from ``load_receiving_concept``
+
     Returns:
-        DataFrame with team-level receiving concept statistics
+        DataFrame with weighted team-level receiving concept statistics
     """
-    # Identify numeric columns for aggregation
+
+    weight_col = 'player_game_count'
+    if weight_col not in df.columns:
+        raise ValueError("Expected 'player_game_count' column for weighting")
+
     numeric_cols = df.select_dtypes(include=['number']).columns.tolist()
-    
-    # Remove ID columns from aggregation
-    exclude_cols = ['player_id', 'franchise_id']
+    exclude_cols = {'player_id', 'franchise_id', weight_col}
     agg_cols = [col for col in numeric_cols if col not in exclude_cols]
-    
-    # Group by team and calculate weighted averages
-    team_stats = df.groupby('team_name')[agg_cols].mean().reset_index()
-    
-    # Add player count
-    team_stats['player_count'] = df.groupby('team_name').size().values
-    
-    return team_stats
+
+    grouped = df.groupby('team_name', dropna=True)
+    records = []
+
+    for team, group in grouped:
+        weights = group[weight_col].fillna(0)
+        weight_sum = weights.sum()
+        record = {
+            'team_name': team,
+            'player_count': len(group),
+            'player_game_count_total': weight_sum,
+        }
+
+        for col in agg_cols:
+            series = group[col]
+            mask = series.notna()
+            if not mask.any():
+                record[col] = np.nan
+                continue
+
+            values = series[mask]
+            w = weights[mask]
+            w_sum = w.sum()
+
+            if w_sum > 0:
+                record[col] = float((values * w).sum() / w_sum)
+            else:
+                record[col] = float(values.mean())
+
+        records.append(record)
+
+    team_stats = pd.DataFrame(records)
+    return team_stats.sort_values('team_name').reset_index(drop=True)

--- a/src/cfb_mismatch/adapters/receiving_scheme.py
+++ b/src/cfb_mismatch/adapters/receiving_scheme.py
@@ -2,8 +2,8 @@
 Adapter for loading receiving scheme statistics.
 """
 
+import numpy as np
 import pandas as pd
-from typing import Optional
 
 
 def load_receiving_scheme(file_path: str) -> pd.DataFrame:
@@ -34,25 +34,52 @@ def load_receiving_scheme(file_path: str) -> pd.DataFrame:
 
 def aggregate_receiving_scheme_by_team(df: pd.DataFrame) -> pd.DataFrame:
     """
-    Aggregate receiving scheme stats by team.
-    
+    Aggregate receiving scheme stats by team using player-game counts as weights.
+
     Args:
-        df: DataFrame from load_receiving_scheme
-        
+        df: DataFrame from ``load_receiving_scheme``
+
     Returns:
-        DataFrame with team-level receiving scheme statistics
+        DataFrame with weighted team-level receiving scheme statistics
     """
-    # Identify numeric columns for aggregation
+
+    weight_col = 'player_game_count'
+    if weight_col not in df.columns:
+        raise ValueError("Expected 'player_game_count' column for weighting")
+
     numeric_cols = df.select_dtypes(include=['number']).columns.tolist()
-    
-    # Remove ID columns from aggregation
-    exclude_cols = ['player_id', 'franchise_id']
+    exclude_cols = {'player_id', 'franchise_id', weight_col}
     agg_cols = [col for col in numeric_cols if col not in exclude_cols]
-    
-    # Group by team and calculate weighted averages
-    team_stats = df.groupby('team_name')[agg_cols].mean().reset_index()
-    
-    # Add player count
-    team_stats['player_count'] = df.groupby('team_name').size().values
-    
-    return team_stats
+
+    grouped = df.groupby('team_name', dropna=True)
+    records = []
+
+    for team, group in grouped:
+        weights = group[weight_col].fillna(0)
+        weight_sum = weights.sum()
+        record = {
+            'team_name': team,
+            'player_count': len(group),
+            'player_game_count_total': weight_sum,
+        }
+
+        for col in agg_cols:
+            series = group[col]
+            mask = series.notna()
+            if not mask.any():
+                record[col] = np.nan
+                continue
+
+            values = series[mask]
+            w = weights[mask]
+            w_sum = w.sum()
+
+            if w_sum > 0:
+                record[col] = float((values * w).sum() / w_sum)
+            else:
+                record[col] = float(values.mean())
+
+        records.append(record)
+
+    team_stats = pd.DataFrame(records)
+    return team_stats.sort_values('team_name').reset_index(drop=True)

--- a/src/cfb_mismatch/cli.py
+++ b/src/cfb_mismatch/cli.py
@@ -59,10 +59,10 @@ def analyze_stats(args):
     # Generate summary report
     print("\nGenerating summary report...")
     if cfbd_team_stats is not None:
-        summary = generate_integrated_report(team_stats, cfbd_team_stats)
+        summary = generate_integrated_report(team_stats, cfbd_team_stats, weights=weights)
         print("✓ Generated integrated report with CFBD data")
     else:
-        summary = generate_summary_report(team_stats)
+        summary = generate_summary_report(team_stats, weights=weights)
         print("✓ Generated summary report (user stats only)")
     
     summary_path = f"{output_dir}/team_summary.csv"
@@ -75,6 +75,11 @@ def analyze_stats(args):
     
     # Display top teams by various metrics
     if not summary.empty:
+        if 'mismatch_score' in summary.columns:
+            print("\n--- Top 5 Teams by Overall Mismatch Score ---")
+            top_mismatch = summary.nlargest(5, 'mismatch_score')[['team_name', 'mismatch_score', 'mismatch_tier']]
+            print(top_mismatch.to_string(index=False))
+
         print("\n--- Top 5 Teams by Man Coverage Grade ---")
         if 'man_coverage_grade' in summary.columns:
             top_man = summary.nlargest(5, 'man_coverage_grade')[['team_name', 'man_coverage_grade']]


### PR DESCRIPTION
## Summary
- weight team-level aggregations by player game counts and retain coverage/receiving headcounts
- compute a configurable mismatch_score with tiers and expose it through the CLI output and CSVs
- document the new outputs and add numpy as a dependency

## Testing
- cfb-mismatch analyze

------
https://chatgpt.com/codex/tasks/task_e_68eff331b1648332acc66f3c6d0ec469